### PR TITLE
erc20-token balanceOf account not fund this balance .$hex be null

### DIFF
--- a/src/Math/Integers.php
+++ b/src/Math/Integers.php
@@ -28,6 +28,9 @@ class Integers
      */
     public static function Unpack(string $hex): BcNumber
     {
+        if($hex == null){
+            return new BcNumber(0);
+        }
         if (substr($hex, 0, 2) === "0x") {
             $hex = substr($hex, 2);
         }


### PR DESCRIPTION
Unpack $hex params be null wrong.
The source of this error is reported when the token is checking the balance. The reason is that when the specified token does not exist in the checked address somewhere, the obtained account hex will return a null value